### PR TITLE
move package imports to inside the Anasol module

### DIFF
--- a/src/Anasol.jl
+++ b/src/Anasol.jl
@@ -1,10 +1,5 @@
 __precompile__()
 
-import DocumentFunction
-import QuadGK
-import Compat
-import Compat.string
-
 """
 MADS: Model Analysis & Decision Support in Julia (Mads.jl v1.0) 2016
 
@@ -39,6 +34,10 @@ module Anasol
 using Base.Cartesian
 import Distributions
 import MetaProgTools
+import DocumentFunction
+import QuadGK
+import Compat
+import Compat.string
 
 include("newanasol.jl")
 


### PR DESCRIPTION
this is more standard, and does imports local to the package
as opposed to globally at top level